### PR TITLE
Fix/Workaround for empty "** left the server" messages.

### DIFF
--- a/TerrariaChatRelay.sln
+++ b/TerrariaChatRelay.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.960
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TerrariaChatRelay", "TerrariaChatRelay/TerrariaChatRelay.csproj", "{3B5DF98F-5B1E-466B-BE21-06EA28044C72}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TerrariaChatRelay", "TerrariaChatRelay/TerrariaChatRelay-TShock.csproj", "{3B5DF98F-5B1E-466B-BE21-06EA28044C72}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/TerrariaChatRelay/Clients/DiscordChatRelay/ChatClient.cs
+++ b/TerrariaChatRelay/Clients/DiscordChatRelay/ChatClient.cs
@@ -270,9 +270,17 @@ namespace DiscordChatRelay
 					outMsg = outMsg.Replace("%bossname%", bossName);
 				}
 
+                // Find the Player Name
 				if(msg.Player == null && (msg.Message.EndsWith(" has joined.") || msg.Message.EndsWith(" has left.")))
 				{
 					string playerName = msg.Message.Replace(" has joined.", "").Replace(" has left.", "");
+
+                    // Suppress empty player name "has left" messages caused by port sniffers
+                    if (playerName.IsNullOrEmpty())
+                    {
+                        // An early return is the easiest way out
+                        return;
+                    }
 
 					outMsg = outMsg.Replace("%playername%", playerName);
 				}


### PR DESCRIPTION
Closes #1 

Fix/Workaround for empty "** left the server" messages. There is probably a way to stop these messages further up stream, but this does work for now.

Also fix the solution file to reference the project file