### PR TITLE
Add new config formats to display player's group prefix and suffix

### DIFF
--- a/TerrariaChatRelay.sln
+++ b/TerrariaChatRelay.sln
@@ -1,20 +1,26 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.960
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30717.126
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TerrariaChatRelay", "TerrariaChatRelay/TerrariaChatRelay-TShock.csproj", "{3B5DF98F-5B1E-466B-BE21-06EA28044C72}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TerrariaChatRelay-TShock", "TerrariaChatRelay\TerrariaChatRelay-TShock.csproj", "{3B5DF98F-5B1E-466B-BE21-06EA28044C72}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3B5DF98F-5B1E-466B-BE21-06EA28044C72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3B5DF98F-5B1E-466B-BE21-06EA28044C72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B5DF98F-5B1E-466B-BE21-06EA28044C72}.Debug|x86.ActiveCfg = Debug|x86
+		{3B5DF98F-5B1E-466B-BE21-06EA28044C72}.Debug|x86.Build.0 = Debug|x86
 		{3B5DF98F-5B1E-466B-BE21-06EA28044C72}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B5DF98F-5B1E-466B-BE21-06EA28044C72}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B5DF98F-5B1E-466B-BE21-06EA28044C72}.Release|x86.ActiveCfg = Release|x86
+		{3B5DF98F-5B1E-466B-BE21-06EA28044C72}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TerrariaChatRelay/Clients/DiscordChatRelay/ChatClient.cs
+++ b/TerrariaChatRelay/Clients/DiscordChatRelay/ChatClient.cs
@@ -275,9 +275,11 @@ namespace DiscordChatRelay
 					outMsg = "%message%";
 
 				if (msg.Player != null)
-					outMsg = outMsg.Replace("%playername%", msg.Player.name);
+                    outMsg = outMsg.Replace("%playername%", msg.Player.name)
+                                   .Replace("%groupprefix%", TShockAPI.TShock.Players[msg.ID].Group.Prefix)
+                                   .Replace("%groupsuffix%", TShockAPI.TShock.Players[msg.ID].Group.Suffix);
 
-				if(msg.Message.EndsWith(" has awoken!"))
+                if (msg.Message.EndsWith(" has awoken!"))
 				{
 					bossName = msg.Message.Replace(" has awoken!", "");
 					outMsg = outMsg.Replace("%bossname%", bossName);

--- a/TerrariaChatRelay/Clients/DiscordChatRelay/Configuration.cs
+++ b/TerrariaChatRelay/Clients/DiscordChatRelay/Configuration.cs
@@ -38,20 +38,24 @@ namespace DiscordChatRelay
 		public string FormatHelp4 { get; set; } = "%message% = Initial message content";
 		[JsonProperty(Order = 55)]
 		public string FormatHelp5 { get; set; } = "%bossname% = Name of boss being summoned (only for VanillaBossSpawned)";
-
 		[JsonProperty(Order = 60)]
-		public static string PlayerChatFormat = ":speech_left: **%playername%:** %message%";
+		public string FormatHelp6 { get; set; } = "%groupprefix% = Group Prefix";
 		[JsonProperty(Order = 65)]
-		public static string PlayerLoggedInFormat = ":small_blue_diamond: **%playername%** joined the server.";
+		public string FormatHelp7 { get; set; } = "%groupsuffix% = Group suffix";
+
+		[JsonProperty(Order = 65)]
+		public static string PlayerChatFormat = ":speech_left: **%playername%:** %message%";
 		[JsonProperty(Order = 75)]
-		public static string PlayerLoggedOutFormat = ":small_orange_diamond: **%playername%** left the server.";
+		public static string PlayerLoggedInFormat = ":small_blue_diamond: **%playername%** joined the server.";
 		[JsonProperty(Order = 85)]
-		public static string WorldEventFormat = "**%message%**";
-		[JsonProperty(Order = 90)]
-		public static string ServerStartingFormat = ":small_blue_diamond: **%message%**";
+		public static string PlayerLoggedOutFormat = ":small_orange_diamond: **%playername%** left the server.";
 		[JsonProperty(Order = 95)]
-		public static string ServerStoppingFormat = ":small_orange_diamond: **%message%**";
+		public static string WorldEventFormat = "**%message%**";
 		[JsonProperty(Order = 100)]
+		public static string ServerStartingFormat = ":small_blue_diamond: **%message%**";
+		[JsonProperty(Order = 105)]
+		public static string ServerStoppingFormat = ":small_orange_diamond: **%message%**";
+		[JsonProperty(Order = 110)]
 		public static string VanillaBossSpawned = ":anger: **%bossname% has awoken!**";
 
 		public Configuration()

--- a/TerrariaChatRelay/Clients/DiscordChatRelay/Configuration.cs
+++ b/TerrariaChatRelay/Clients/DiscordChatRelay/Configuration.cs
@@ -43,19 +43,19 @@ namespace DiscordChatRelay
 		[JsonProperty(Order = 65)]
 		public string FormatHelp7 { get; set; } = "%groupsuffix% = Group suffix";
 
-		[JsonProperty(Order = 65)]
+		[JsonProperty(Order = 70)]
 		public static string PlayerChatFormat = ":speech_left: **%playername%:** %message%";
-		[JsonProperty(Order = 75)]
+		[JsonProperty(Order = 80)]
 		public static string PlayerLoggedInFormat = ":small_blue_diamond: **%playername%** joined the server.";
-		[JsonProperty(Order = 85)]
+		[JsonProperty(Order = 90)]
 		public static string PlayerLoggedOutFormat = ":small_orange_diamond: **%playername%** left the server.";
-		[JsonProperty(Order = 95)]
-		public static string WorldEventFormat = "**%message%**";
 		[JsonProperty(Order = 100)]
-		public static string ServerStartingFormat = ":small_blue_diamond: **%message%**";
+		public static string WorldEventFormat = "**%message%**";
 		[JsonProperty(Order = 105)]
-		public static string ServerStoppingFormat = ":small_orange_diamond: **%message%**";
+		public static string ServerStartingFormat = ":small_blue_diamond: **%message%**";
 		[JsonProperty(Order = 110)]
+		public static string ServerStoppingFormat = ":small_orange_diamond: **%message%**";
+		[JsonProperty(Order = 115)]
 		public static string VanillaBossSpawned = ":anger: **%bossname% has awoken!**";
 
 		public Configuration()

--- a/TerrariaChatRelay/Core/EventManager.cs
+++ b/TerrariaChatRelay/Core/EventManager.cs
@@ -86,6 +86,7 @@ namespace TerrariaChatRelay
         public Player Player { get; set; }
         public Color Color { get; set; }
         public string Message { get; set; }
+		public int ID { get; set; }
 
 		/// <summary>
 		/// Message payload sent to subscribers when a game message has been received.
@@ -99,6 +100,7 @@ namespace TerrariaChatRelay
 				Player = Terraria.Main.player[playerId] ?? null;
 			Color = color;
             Message = msg;
-        }
+			ID = playerId;
+		}
     }
 }

--- a/TerrariaChatRelay/TerrariaChatRelay-TShock.csproj
+++ b/TerrariaChatRelay/TerrariaChatRelay-TShock.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TerrariaChatRelay</RootNamespace>
     <AssemblyName>TerrariaChatRelay</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -29,6 +30,24 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">


### PR DESCRIPTION
Adds a few line of codes to display player's group prefix and suffix.
![image](https://user-images.githubusercontent.com/59508429/133724819-0eb5c7f7-222b-4c51-9f0c-f45ca433ed53.png)
ref #15 (Group)

Also changed .NET Framework from 4.5 to 4.5.2, this solves my problem of constant disconnects from Discord server.