### PR TITLE
Fix an issue where PlayersOnline command displays incorrect player cap.

### DIFF
--- a/TCR-TerrariaChatRelay/Command/Commands/CmdPlayersOnline.cs
+++ b/TCR-TerrariaChatRelay/Command/Commands/CmdPlayersOnline.cs
@@ -20,7 +20,11 @@ namespace TerrariaChatRelay.Command.Commands
 		public string Execute(string input = null, TCRClientUser whoRanCommand = null)
 		{
 			var players = Terraria.Main.player.Where(x => x.name.Length != 0);
-			return $"</b>Players Online:</b> {players.Count()} / {Terraria.Main.player.Length}" + "</br></box>" + string.Join(", ", players.Select(x => x.name)).Replace("`", "") + "</box>";
+			if (players.Count() == 0)
+			{
+				return $"</box>No players online!</box>";
+			}
+			return $"</b>Players Online:</b> {players.Count()} / {Terraria.Main.maxNetPlayers}" + "</br></box>" + string.Join(", ", players.Select(x => x.name)).Replace("`", "") + "</box>";
 		}
 	}
 


### PR DESCRIPTION
- Fixes an issue where PlayersOnline command displays incorrect player cap.
- Added "No players online!" when there's no players online.