### PR TITLE
Minor Fixes about EOL BossID and Ban Commands.

### DIFF
--- a/TCR-TShock/Commands/CmdBanPlayer.cs
+++ b/TCR-TShock/Commands/CmdBanPlayer.cs
@@ -4,10 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Terraria;
+using TShockAPI.DB;
 
 namespace TerrariaChatRelay.Command.Commands
 {
-	// [Command]
+	[Command]
 	public class CmdBanPlayer : ICommand
 	{
 		public string Name { get; } = "Ban Player";
@@ -16,27 +17,83 @@ namespace TerrariaChatRelay.Command.Commands
 
 		public string Description { get; } = "Bans the specified player. (Careful not to trigger other Discord bots!)";
 
-		public string Usage { get; } = "ban PlayerName";
+		public string Usage { get; } = "ban PlayerName, silent/loud, reason, duration(s/m/d)";
 
 		public Permission DefaultPermissionLevel { get; } = Permission.Manager;
 
 		public string Execute(string input = null, TCRClientUser whoRanCommand = null)
 		{
 			input = input.ToLower();
+
 			if (input == null || input == "")
-				return "Specify a player to ban. Example: \"ban AnOnlinePlayer\"";
+				return "Specify a player to ban. Example: ban AnOnlinePlayer, s/l, hacking, 2d";
 
-			for (var i = 0; i < Main.player.Length; i++)
+			String[] spearator = { ", " };
+			Int32 count = 4;
+			String[] parameters = input.Split(spearator, count, StringSplitOptions.RemoveEmptyEntries);
+
+			AddBanResult banResult;
+			string reason = "Banned.";
+			string duration = null;
+			var result = new System.Text.StringBuilder();
+			DateTime expiration = DateTime.MaxValue;
+
+
+			if(parameters.Count() < 3)
+            {
+				return "Invalid syntax. Example : ban AnOnlinePlayer, s/l, hacking, 2d";
+            }
+
+			if (parameters.Count() == 4)
 			{
-				if (Main.player[i].name.ToLower() == input)
-				{
-					input = input.Remove(0, Main.player[i].name.Length - 1);
-					TShockAPI.TShock.Players[i].Ban(input);
+				duration = parameters[3];
+			}
 
-					return "";
+			if (parameters.Count() >= 3)
+			{
+				reason = parameters[2];
+			}
+
+			if (TShockAPI.TShock.Utils.TryParseTime(duration, out int seconds))
+			{
+				expiration = DateTime.UtcNow.AddSeconds(seconds);
+			}
+
+			var players = TShockAPI.TSPlayer.FindByNameOrID(parameters[0]);
+			if (players.Count > 1)
+			{
+				return "Found more than one matching players.";
+			}
+
+			if (players.Count < 1)
+			{
+				return "Could not find the target specified. Check that you have the correct spelling.";
+			}
+			var player = players[0];
+			string[] identifier = { $"acc:{player.Name}", $"ip:{player.IP}", $"uuid:{player.UUID}", $"name:{player.Account.Name}"};
+            
+			for (int i=0; i<=3; i++)
+            {
+				banResult = TShockAPI.TShock.Bans.InsertBan(identifier[i], reason, $"TerrariaChatRelay : {whoRanCommand.Username}", DateTime.UtcNow, expiration);
+				if (parameters[1] == "loud" || parameters[1] == "l")
+				{
+					if (banResult.Ban != null)
+					{
+						result.Append($"Ban added. Ticket Number {banResult.Ban.TicketNumber} was created for identifier {identifier[i]}.\n");
+					}
+					else
+					{
+						result.Append($"Failed to add ban for identifier: {identifier[i]}\n");
+						result.Append($"Reason: {banResult.Message}\n");
+					}
 				}
 			}
-			return "Player not found.";
+			player.Disconnect($"You have been banned: {reason}.\n");
+
+			if (parameters[1] == "silent" || parameters[1] == "s")
+				return "Command Executed!";
+
+			return result.ToString();
 		}
 	}
 }

--- a/TCR-TShock/Commands/CmdUnbanPlayer.cs
+++ b/TCR-TShock/Commands/CmdUnbanPlayer.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using TShockAPI.DB;
+
+namespace TerrariaChatRelay.Command.Commands
+{
+	[Command]
+	public class CmdUnbanPlayer : ICommand
+	{
+		public string Name { get; } = "Unban Player";
+
+		public string CommandKey { get; } = "unban";
+
+		public string Description { get; } = "Unbans the specified player.";
+
+		public string Usage { get; } = "unban banID";
+
+		public Permission DefaultPermissionLevel { get; } = Permission.Manager;
+
+		public string Execute(string input = null, TCRClientUser whoRanCommand = null)
+		{
+			input = input.ToLower();
+			if (!int.TryParse(input, out int banId))
+			{
+				return $"Invalid Ticket Number.";
+			}
+
+			if (TShockAPI.TShock.Bans.RemoveBan(banId))
+			{
+				TShockAPI.TShock.Log.ConsoleInfo($"Ban {banId} has been revoked by \"TerrariaRelayChat : {whoRanCommand.Username}\".");
+				return $"Ban {banId} has now been marked as expired.";
+			}
+
+			return "";
+		}
+	}
+}

--- a/TCR-TShock/TCR-TShock.csproj
+++ b/TCR-TShock/TCR-TShock.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Commands\CmdConsoleCommand.cs" />
     <Compile Include="Commands\CmdKickPlayer.cs" />
     <Compile Include="Commands\CmdSpawnNPC.cs" />
+    <Compile Include="Commands\CmdUnbanPlayer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TerrariaChatRelayTShock.cs" />
   </ItemGroup>

--- a/TCR-TShock/TerrariaChatRelayTShock.cs
+++ b/TCR-TShock/TerrariaChatRelayTShock.cs
@@ -59,6 +59,7 @@ namespace TCRTShock
 			134, // The Destroyer
 			262, // Plantera
 			245, // Golem
+			636, // Empress Of Light
 			370, // Duke Fishron
 			439, // Lunatic Cultist
 			396 // Moon Lord


### PR DESCRIPTION
Changes 
- Fixed Ban Command.
- Added Unban Command.
- Fixed "Empress Of Light has Awoken" not showing in Discord.

New Ban Command Syntax:
!ban Playername, silent/loud*, reason, duration**

*= (loud / l) will send the ban details over to Discord, (silent / s) will hide the ban details.
**= duration format (s/m/d) ex. 4d for 4 days. Let it empty to permanently ban players.

Unban Command Syntax:
!unban BanID