### PR TITLE
Fix System.ArgumentOutOfRangeException if the message is too short.

### DIFF
--- a/TCR-TerrariaChatRelay/Command/CommandService.cs
+++ b/TCR-TerrariaChatRelay/Command/CommandService.cs
@@ -23,18 +23,21 @@ namespace TerrariaChatRelay
 		/// <returns>True if a command key is found. False if not.</returns>
 		public bool IsCommand(string input, string commandPrefix)
 		{
-			if(input.Length > commandPrefix.Length)
+			if (input.Length > commandPrefix.Length)
 			{
 				if (!input.StartsWith(commandPrefix))
 					return false;
+
+				string newinput = input.ToLower().Remove(0, commandPrefix.Length);
+
+				int indexOfSeparator = newinput.IndexOf(' ');
+				if (indexOfSeparator > 0)
+					newinput = newinput.Substring(0, indexOfSeparator);
+
+				return Commands.ContainsKey(newinput);
 			}
-			string newinput = input.ToLower().Remove(0, commandPrefix.Length);
 
-			int indexOfSeparator = newinput.IndexOf(' ');
-			if (indexOfSeparator > 0)
-				newinput = newinput.Substring(0, indexOfSeparator);
-
-			return Commands.ContainsKey(newinput);
+			return false;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fix `System.ArgumentOutOfRangeException` if `input.Length < commandPrefix.Length`.